### PR TITLE
docs: remove TeamCity badge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,5 @@
 # Kubernetes on DC/OS
 
-<a href="http://teamcity.mesosphere.io/viewType.html?buildTypeId=ClosedSource_KubernetesAws_PrTest&guest=1">
-<img src="http://teamcity.mesosphere.io/app/rest/builds/buildType:(id:ClosedSource_KubernetesAws_PrTest)/statusIcon"/>
-</a>
-
-
 Kubernetes is now available as a DC/OS package to quickly, and reliably run Kubernetes clusters on Mesosphere DC/OS.
 
 ![](docs/assets/ui-install.gif)


### PR DESCRIPTION
This PR removes TeamCity badge introduced in #9 because it's meaningless (and misleading) to the community, since the community:
* have access to the framework code, or
* can't access TeamCity (as the screenshot below shows), or even
* only have access to releases that for sure have passed TeamCity builds.

<img width="1680" alt="screen shot 2017-09-19 at 10 53 04" src="https://user-images.githubusercontent.com/1752631/30586923-5ca90964-9d29-11e7-8137-85705b26d204.png">
