### PR TITLE
Files: minor changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN curl -o dcos https://downloads.dcos.io/binaries/cli/linux/x86-64/$DCOS_LAUNC
 RUN curl -o dcos-launch https://downloads.dcos.io/dcos-launch/bin/linux/dcos-launch \
     && chmod +x dcos-launch
 
-ENV KUBERNETES_VERSION v1.7.6
+ENV KUBERNETES_VERSION v1.7.7
 ENV KUBERNETES_DOWNLOAD_URL https://storage.googleapis.com/kubernetes-release/release/$KUBERNETES_VERSION/bin/linux/amd64/kubectl
 RUN curl -fsSL "$KUBERNETES_DOWNLOAD_URL" -o kubectl \
   && chmod +x kubectl

--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ NUM_MASTERS := $(if ${NUM_MASTERS},${NUM_MASTERS},1)
 define docker_container
 	docker run -i \
 		-v $(GOOGLE_APPLICATION_CREDS):/credentials.json \
-		-e GOOGLE_APPLICATION_CREDENTIALS=/credentials.json \
+		-e GCE_CREDENTIALS_PATH=/credentials.json \
 		-e AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} \
 		-e AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} \
 		-e NUM_PRIVATE_AGENTS=${NUM_PRIVATE_AGENTS} \

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Kubernetes is now available as a DC/OS package to quickly, and reliably run Kube
 
 ## Pre-Requisites
 
-* Google Cloud (GCE) credentials ([AWS](docs/aws.md) and [Azure](docs/azure.md) are supported as well) with the necessary [permissions](docs/gce-service-account.md)
+* Google Cloud (GCE) credentials ([AWS](docs/aws.md) and [Azure](docs/azure.md) are supported as well) with the necessary [permissions](docs/gce.md)
 * Linux/Mac machine to execute the samples below
 * Docker CE 17+
 
@@ -52,9 +52,9 @@ $ kubectl get nodes
 # If you see a result like this, everything is working properly, and you are now running Kubernetes on DC/OS.
 
 NAME                                   STATUS    AGE       VERSION
-kube-node-0-kubelet.kubernetes.mesos   Ready     13s       v1.7.5
-kube-node-1-kubelet.kubernetes.mesos   Ready     13s       v1.7.5
-kube-node-2-kubelet.kubernetes.mesos   Ready     13s       v1.7.5
+kube-node-0-kubelet.kubernetes.mesos   Ready     13s       v1.7.7
+kube-node-1-kubelet.kubernetes.mesos   Ready     13s       v1.7.7
+kube-node-2-kubelet.kubernetes.mesos   Ready     13s       v1.7.7
 
 make uninstall
 # Uninstalls kubernetes.
@@ -148,9 +148,9 @@ Test access by retrieving the Kubernetes cluster nodes:
 ```bash
 $ kubectl get nodes
 NAME                                   STATUS    AGE       VERSION
-kube-node-0-kubelet.kubernetes.mesos   Ready     7m        v1.7.5
-kube-node-1-kubelet.kubernetes.mesos   Ready     7m        v1.7.5
-kube-node-2-kubelet.kubernetes.mesos   Ready     7m        v1.7.5
+kube-node-0-kubelet.kubernetes.mesos   Ready     7m        v1.7.7
+kube-node-1-kubelet.kubernetes.mesos   Ready     7m        v1.7.7
+kube-node-2-kubelet.kubernetes.mesos   Ready     7m        v1.7.7
 ```
 
 ## Deploy Kubernetes workloads on DCOS
@@ -159,4 +159,4 @@ To deploy your first Kubernetes workloads on DC/OS, please see the [examples fol
 
 ## Documents
 
-For more details, please see the [docs folder](docs) as well was the official [service docs](https://docs.mesosphere.com/service-docs/beta-kubernetes/0.2.0-1.7.6-beta)
+For more details, please see the [docs folder](docs) as well was the official [service docs](https://docs.mesosphere.com/service-docs/beta-kubernetes/0.2.1-1.7.7-beta)

--- a/docs/aws.md
+++ b/docs/aws.md
@@ -7,18 +7,20 @@ export AWS_ACCESS_KEY_ID=<YOUR ACCESS KEY>
 export AWS_SECRET_ACCESS_KEY=<YOUR SECRET KEY>
 ```
 
+Note that, you could experience some issues due to insufficient resource limits of your account. You can verify your default limits [here](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-resource-limits.html).
+
 You can then pass the platform variable to the `launch-dcos` command
 
 ```
 make docker
 # You are now in a container.
-make launch-dcos PLATFORM=aws 
+make launch-dcos PLATFORM=aws
 # Launches DC/OS cluster. The cluster provisioning will take ~15 minutes.  
-make setup-cli 
+make setup-cli
 # Configures the DC/OS CLI and kubectl.
-make install 
+make install
 # Installs kubernetes on your cluster. Takes ~2 minutes.
-make kubectl-tunnel PLATFORM=aws 
+make kubectl-tunnel PLATFORM=aws
 # Creates a ssh tunnel to a node-agent for APIServer access.
 # Make sure the API Server and Kubelets are up by running:
 
@@ -27,13 +29,13 @@ kubectl get nodes
 # If you see a result like this, everything is working properly, and you are now running Kubernetes on DC/OS.
 
 NAME                                   STATUS    AGE       VERSION
-kube-node-0-kubelet.kubernetes.mesos   Ready     13s       v1.7.5 
-kube-node-1-kubelet.kubernetes.mesos   Ready     13s       v1.7.5 
-kube-node-2-kubelet.kubernetes.mesos   Ready     13s       v1.7.5 
+kube-node-0-kubelet.kubernetes.mesos   Ready     13s       v1.7.7
+kube-node-1-kubelet.kubernetes.mesos   Ready     13s       v1.7.7
+kube-node-2-kubelet.kubernetes.mesos   Ready     13s       v1.7.7
 
-make uninstall 
+make uninstall
 # Uninstalls kubernetes.
-make destroy-dcos 
+make destroy-dcos
 # Deletes the DC/OS cluster.
 ```
 ```

--- a/docs/gce.md
+++ b/docs/gce.md
@@ -9,3 +9,7 @@ gcloud iam service-accounts keys create key.json --iam-account=nick-960@cool-pro
 
 ```
 You can find more information on how to create a service account [here](https://cloud.google.com/compute/docs/access/create-enable-service-accounts-for-instances). Note the location of this downloaded key as you will use it to provision a GCE cluster.
+
+# Google Cloud Platform Resource Quotas
+
+When deploying our cluster, you might experience some issues related to insufficient  resource limits. Consequently, we recommend to verify your default limits [here](https://cloud.google.com/compute/quotas).


### PR DESCRIPTION
- Use the same kubernetes version for the client and the server binaries
- Add links to AWS and GCP pages to check the default resource limits
- Set GCE_CREDENTIALS_PATH environment variable to fix https://github.com/mesosphere/dcos-kubernetes-quickstart/issues/22