### PR TITLE
Dockerfile: clone and build docs-launch from its repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN yum update -y && yum install -y epel-release && yum install -y \
   which \
   sudo && yum clean all
 
-RUN pip3 install awscli
+RUN pip3 install awscli typing
 
 WORKDIR /usr/local/bin
 # Install required binaries: dcos, dcos-launch and kubectl
@@ -23,8 +23,11 @@ ENV DCOS_LAUNCH_VERSION 0.5.6
 RUN curl -o dcos https://downloads.dcos.io/binaries/cli/linux/x86-64/$DCOS_LAUNCH_VERSION/dcos \
     && chmod +x dcos
 
-RUN curl -o dcos-launch https://downloads.dcos.io/dcos-launch/bin/linux/dcos-launch \
-    && chmod +x dcos-launch
+RUN git clone https://github.com/dcos/dcos-launch.git && \
+    cd dcos-launch && \
+    git checkout 261ab82af4fd0a4daa207c7c2328d8eebcdd57b7 && \
+    pip3 install -r requirements.txt && \
+    python3 setup.py develop
 
 ENV KUBERNETES_VERSION v1.9.0
 ENV KUBERNETES_DOWNLOAD_URL https://storage.googleapis.com/kubernetes-release/release/$KUBERNETES_VERSION/bin/linux/amd64/kubectl


### PR DESCRIPTION
We need to upgrade dcos-launch and use the same version used in `dcos-kubernetes` repo. 

In relation to this issue https://github.com/mesosphere/dcos-kubernetes-quickstart/issues/43, I verified and our `dcos-launch` version (`261ab82af4fd0a4daa207c7c2328d8eebcdd57b7`) always deletes the instance group and its template. It seems to be a version related problem.