### PR TITLE
rename the destroy-dcos target to destroy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,13 +139,11 @@ upgrade-dcos: check-terraform
 	$(TERRAFORM_CMD) apply -var-file desired_cluster_profile.tfvars -var state=upgrade -target null_resource.bootstrap -target null_resource.master -parallelism=1; \
 	$(TERRAFORM_CMD) apply -var-file desired_cluster_profile.tfvars -var state=upgrade
 
-destroy-dcos: check-terraform
+destroy: check-terraform
 	$(RM) $(MASTER_IP_FILE)
 	$(RM) $(MASTER_LB_IP_FILE)
 	cd .deploy; \
 	$(TERRAFORM_CMD) destroy $(TERRAFORM_DESTROY_ARGS) -var-file desired_cluster_profile
-
-destroy: uninstall destroy-dcos
 
 clean:
 	$(RM) -r .deploy dcos kubectl

--- a/README.md
+++ b/README.md
@@ -170,6 +170,19 @@ $ make kubectl-tunnel
 
 If `kubectl` is properly configured and the tunnel established successfully, in another terminal you should now be able to run `kubectl proxy` as well as any other command.
 
+## Uninstall Kubernetes
+
+To uninstall the DC/OS Kubernetes package while leaving your DC/OS cluster up,
+run:
+
+```bash
+$ make uninstall
+```
+
+**NOTE:** This will only uninstall Kubernetes. Make sure you destroy your DC/OS
+cluster using the instructions below when you finish testing, or otherwise you
+will need to delete all cloud resources manually!
+
 ## Destroy cluster
 
 To destroy the whole deployment:

--- a/README.md
+++ b/README.md
@@ -178,20 +178,6 @@ To destroy the whole deployment:
 $ make destroy
 ```
 
-Alternatively, you can separately uninstall Kubernetes:
-
-```bash
-$ make uninstall
-```
-
-And delete the DC/OS cluster:
-
-```bash
-$ make destroy-dcos
-```
-
-**ATTENTION:** Make sure to run `make destroy-dcos` or otherwise you will need to delete all cloud resources manually!
-
 Last, clean generated resources:
 ```
 make clean


### PR DESCRIPTION
`make destroy` and `make destroy-dcos` end up having the same effect (i.e., destroying the cluster), so we may as well keep a single one around.