### PR TITLE
docs: update cncf conformance instructions

### DIFF
--- a/docs/cncf_conformance.md
+++ b/docs/cncf_conformance.md
@@ -88,7 +88,8 @@ OpenID token to the shell where you ran the above mentioned command.
 To install `dcos-kubernetes` in the newly created DC/OS cluster run:
 
 ```shell
-$ KUBERNETES_FRAMEWORK_VERSION=1.1.1-1.10.4 ./dcos package install --yes --options=./resources/options-ha.json kubernetes
+$ KUBERNETES_FRAMEWORK_VERSION=1.1.1-1.10.4 \
+  PATH_TO_PACKAGE_OPTIONS=./resources/options-ha.json make install
 ```
 
 Wait until all tasks are running before proceeding. You can track installation
@@ -142,15 +143,15 @@ process and proceed to access your Kubernetes cluster.
 ## Accessing the Kubernetes API
 
 In order to access the Kubernetes API from outside the DC/OS cluster, we must
-first be able to access it. For now, we can achieve this through an SSH tunnel:
+first be able to access it. This can be achieved by running the following
+command:
 
 ```shell
-$ make kubectl-tunnel
+$ make kubeconfig
 ```
 
-The command above will block your terminal session, so you will need a new one
-to check that `kubectl` can communicate with your new cluster. Let's try and
-list the Kubernetes cluster nodes:
+This command will configure `kubectl` to access our DC/OS Kubernetes cluster.
+Let's try and list this cluster's nodes:
 
 ```shell
 $ ./kubectl get nodes

--- a/docs/exposing_kubernetes_api.md
+++ b/docs/exposing_kubernetes_api.md
@@ -31,7 +31,7 @@ The dummy Marathon application `kubeapi-proxy` definition:
     "HAPROXY_0_MODE": "http",
     "HAPROXY_0_PORT": "6443",
     "HAPROXY_0_SSL_CERT": "/etc/ssl/cert.pem",
-    "HAPROXY_0_BACKEND_SERVER_OPTIONS": "  server kube-apiserver apiserver.kubernetes.l4lb.thisdcos.directory:6443 ssl verify none\n"   
+    "HAPROXY_0_BACKEND_SERVER_OPTIONS": "  timeout connect 10s\n  timeout client 86400s\n  timeout server 86400s\n  timeout tunnel 86400s\n  server kube-apiserver apiserver.kubernetes.l4lb.thisdcos.directory:6443 ssl verify none\n"   
   }
 }
 ```

--- a/resources/kubeapi-proxy.json
+++ b/resources/kubeapi-proxy.json
@@ -18,6 +18,6 @@
     "HAPROXY_GROUP": "external",
     "HAPROXY_0_SSL_CERT": "/etc/ssl/cert.pem",
     "HAPROXY_0_PORT": "6443",
-    "HAPROXY_0_BACKEND_SERVER_OPTIONS": "  server kube-apiserver apiserver.kubernetes.l4lb.thisdcos.directory:6443 ssl verify none\n"
+    "HAPROXY_0_BACKEND_SERVER_OPTIONS": "  timeout connect 10s\n  timeout client 86400s\n  timeout server 86400s\n  timeout tunnel 86400s\n  server kube-apiserver apiserver.kubernetes.l4lb.thisdcos.directory:6443 ssl verify none\n"
   }
 }

--- a/resources/options-ha.json
+++ b/resources/options-ha.json
@@ -1,5 +1,6 @@
 {
   "kubernetes": {
+    "authorization_mode": "RBAC",
     "high_availability": true,
     "node_count": 3,
     "public_node_count": 1

--- a/scripts/poll_api.sh
+++ b/scripts/poll_api.sh
@@ -8,7 +8,7 @@ echo " "
 echo "Waiting for ${API_NAME} to be ready..."
 if [[ "${API_NAME}" = "Kubernetes API" ]]
 then
-  until curl -o /dev/null -skIf -w "%{http_code}" https://${API_IP}:${API_PORT} | grep -w "401" >/dev/null 2>&1; do sleep 1; done
+  until curl -o /dev/null -skIf -w "%{http_code}" https://${API_IP}:${API_PORT} | grep -w "401\|403" >/dev/null 2>&1; do sleep 1; done
 else
   until curl -o /dev/null -skIf https://${API_IP}:${API_PORT}; do sleep 1; done
 fi


### PR DESCRIPTION
This PR aims at removing the need for the SSH tunnel when running the CNCF conformance tests. I am not removing the `kubectl-tunnel` target from the Makefile as it may still be useful in some scenarios. The following changes are being introduced:

* Update the timeouts used in Marathon-LB.
* Do not modify the system's `PATH` environment variable.
* Fix a bug which caused the binaries not to be found in some systems even though they were in the `PATH`.
* Add a `PATH_TO_PACKAGE_OPTIONS` Makefile variable that can be used to specify the file to use when installing (useful for the CNCF guide).
* Use `kubernetes.authorization_mode` for CNCF.
* Update the polling scripts in order to wait for a `401` or `403` status code from the API.