### PR TITLE
bump quick-start to 2.0.1-1.12.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ SSH_USER := core
 TERRAFORM_INSTALLER_URL := github.com/dcos/terraform-dcos
 DCOS_VERSION := 1.12
 CUSTOM_DCOS_DOWNLOAD_PATH := https://downloads.dcos.io/dcos/stable/1.12.0/dcos_generate_config.sh
-KUBERNETES_VERSION ?= 1.12.1
-KUBERNETES_FRAMEWORK_VERSION ?= 2.0.0-1.12.1
+KUBERNETES_VERSION ?= 1.12.2
+KUBERNETES_FRAMEWORK_VERSION ?= 2.0.1-1.12.2
 # PATH_TO_PACKAGE_OPTIONS holds the path to the package options file to be used
 # when installing DC/OS Kubernetes.
 PATH_TO_PACKAGE_OPTIONS ?= "$(PWD)/.deploy/options.json"

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Kubernetes is now available as a DC/OS package to quickly, and reliably run Kube
 
 ![](docs/assets/ui-install.gif)
 
-**NOTE:** The latest `dcos-kubernetes-quickstart` doesn't support any Kubernetes framework version before `2.0.0-1.12.1`. The reason is that now creating Kubernetes clusters requires the installation of the [Mesosphere Kubernetes Engine](https://docs.mesosphere.com/services/kubernetes/2.0.0-1.12.1/overview/#cluster-manager).
+**NOTE:** The latest `dcos-kubernetes-quickstart` doesn't support any Kubernetes framework version before `2.0.0-1.12.1`. The reason is that now creating Kubernetes clusters requires the installation of the [Mesosphere Kubernetes Engine](https://docs.mesosphere.com/services/kubernetes/2.0.1-1.12.2/overview/#cluster-manager).
 
 ## Known limitations
 
-Before proceeding, please check the [current package limitations](https://docs.mesosphere.com/service-docs/kubernetes/2.0.0-1.12.1/limitations/).
+Before proceeding, please check the [current package limitations](https://docs.mesosphere.com/service-docs/kubernetes/2.0.1-1.12.2/limitations/).
 
 ## Pre-Requisites
 
@@ -75,7 +75,7 @@ For more advanced scenarios, please check the [terraform-dcos documentation for 
 
 **NOTE:** This `quickstart` will provision a Kubernetes cluster without `RBAC` support.
 
-To deploy a cluster with enabled [RBAC](https://docs.mesosphere.com/services/kubernetes/2.0.0-1.12.1/operations/authn-and-authz/#rbac) update `.deploy/options.json`:
+To deploy a cluster with enabled [RBAC](https://docs.mesosphere.com/services/kubernetes/2.0.1-1.12.2/operations/authn-and-authz/#rbac) update `.deploy/options.json`:
 
 ```
 {
@@ -88,7 +88,7 @@ To deploy a cluster with enabled [RBAC](https://docs.mesosphere.com/services/kub
 }
 ```
 
-If you want to give users access to the Kubernetes API check [documentation](https://docs.mesosphere.com/services/kubernetes/2.0.0-1.12.1/operations/authn-and-authz/#giving-users-access-to-the-kubernetes-api).
+If you want to give users access to the Kubernetes API check [documentation](https://docs.mesosphere.com/services/kubernetes/2.0.1-1.12.2/operations/authn-and-authz/#giving-users-access-to-the-kubernetes-api).
 
 **NOTE:** The authorization mode for a cluster must be chosen when installing the package. Changing the authorization mode after installing the package is not supported.
 
@@ -195,8 +195,8 @@ Let's test accessing the Kubernetes API and list the Kubernetes cluster nodes:
 ```bash
 $ ./kubectl --context devkubernetes01 get nodes
 NAME                                                  STATUS   ROLES    AGE     VERSION
-kube-control-plane-0-instance.devkubernetes01.mesos   Ready    master   5m18s   v1.12.1
-kube-node-0-kubelet.devkubernetes01.mesos             Ready    <none>   2m58s   v1.12.1
+kube-control-plane-0-instance.devkubernetes01.mesos   Ready    master   5m18s   v1.12.2
+kube-node-0-kubelet.devkubernetes01.mesos             Ready    <none>   2m58s   v1.12.2
 ```
 
 And now, let's check how the system Kubernetes pods are doing:
@@ -231,7 +231,7 @@ Then pointing your browser at:
 http://127.0.0.1:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/
 ```
 
-Please note that you will have to sign-in into the [Kubernetes Dashboard](https://docs.mesosphere.com/services/kubernetes/2.0.0-1.12.1/operations/kubernetes-dashboard/#login-view-and-authorization) before being able to perform any action.
+Please note that you will have to sign-in into the [Kubernetes Dashboard](https://docs.mesosphere.com/services/kubernetes/2.0.1-1.12.2/operations/kubernetes-dashboard/#login-view-and-authorization) before being able to perform any action.
 
 ## Uninstall Kubernetes
 
@@ -261,7 +261,7 @@ $ make clean
 
 ## Documentation
 
-For more details, please see the [docs folder](docs) and as well check the official [service docs](https://docs.mesosphere.com/service-docs/kubernetes/2.0.0-1.12.1)
+For more details, please see the [docs folder](docs) and as well check the official [service docs](https://docs.mesosphere.com/service-docs/kubernetes/2.0.1-1.12.2)
 
 ## Community
 Get help and connect with other users on the [mailing list](https://groups.google.com/a/dcos.io/forum/#!forum/kubernetes) or on DC/OS community [Slack](http://chat.dcos.io/) in the #kubernetes channel.

--- a/docs/cncf_conformance.md
+++ b/docs/cncf_conformance.md
@@ -70,7 +70,7 @@ admin_cidr = "0.0.0.0/0"
 Now, launch the DC/OS cluster by running:
 
 ```shell
-$ KUBERNETES_VERSION=1.12.1 make get-cli launch-dcos setup-cli
+$ KUBERNETES_VERSION=1.12.2 make get-cli launch-dcos setup-cli
 ```
 
 This command will:
@@ -140,12 +140,12 @@ Let's try and list this cluster's nodes:
 ```shell
 $ ./kubectl --context devkubernetes01 get nodes
 NAME                                                  STATUS   ROLES    AGE     VERSION
-kube-control-plane-0-instance.devkubernetes01.mesos   Ready    master   5m18s   v1.12.1
-kube-control-plane-1-instance.devkubernetes01.mesos   Ready    master   5m12s   v1.12.1
-kube-control-plane-2-instance.devkubernetes01.mesos   Ready    master   5m11s   v1.12.1
-kube-node-0-kubelet.devkubernetes01.mesos             Ready    <none>   2m58s   v1.12.1
-kube-node-1-kubelet.devkubernetes01.mesos             Ready    <none>   2m42s   v1.12.1
-kube-node-2-kubelet.devkubernetes01.mesos             Ready    <none>   2m39s   v1.12.1
+kube-control-plane-0-instance.devkubernetes01.mesos   Ready    master   5m18s   v1.12.2
+kube-control-plane-1-instance.devkubernetes01.mesos   Ready    master   5m12s   v1.12.2
+kube-control-plane-2-instance.devkubernetes01.mesos   Ready    master   5m11s   v1.12.2
+kube-node-0-kubelet.devkubernetes01.mesos             Ready    <none>   2m58s   v1.12.2
+kube-node-1-kubelet.devkubernetes01.mesos             Ready    <none>   2m42s   v1.12.2
+kube-node-2-kubelet.devkubernetes01.mesos             Ready    <none>   2m39s   v1.12.2
 ```
 
 If the output is similar to what is shown above, you're good to go and run the

--- a/docs/existing_cluster.md
+++ b/docs/existing_cluster.md
@@ -2,7 +2,7 @@
 
 If you already have a DC/OS 1.11+ cluster, Kubernetes is publicly available in the Catalog.
 
-Before proceeding, make sure your cluster fulfils the [Kubernetes package default requirements](https://docs.mesosphere.com/services/kubernetes/2.0.0-1.12.1/getting-started/install-basic/#prerequisites).
+Before proceeding, make sure your cluster fulfils the [Kubernetes package default requirements](https://docs.mesosphere.com/services/kubernetes/2.0.1-1.12.2/getting-started/install-basic/#prerequisites).
 
 Then, install is as easy as:
 

--- a/docs/exposing_kubernetes_api.md
+++ b/docs/exposing_kubernetes_api.md
@@ -45,4 +45,4 @@ Here is how this works:
 1. `"HAPROXY_0_SSL_CERT": "/etc/ssl/cert.pem"` tells Marathon-LB to expose the service with the self-signed Marathon-LB certificate (which has **no CN**)
 1. The last label `HAPROXY_0_BACKEND_SERVER_OPTIONS` indicates that Marathon-LB should forward traffic to the endpoint `apiserver.kubernetes.l4lb.thisdcos.directory:6443` rather than to the dummy application, and that the connection should be made using TLS without verification.
 
-For more options of exposing Kubernetes API, please check the [documentation](https://docs.mesosphere.com/services/kubernetes/2.0.0-1.12.1/operations/exposing-the-kubernetes-api/).
+For more options of exposing Kubernetes API, please check the [documentation](https://docs.mesosphere.com/services/kubernetes/2.0.1-1.12.2/operations/exposing-the-kubernetes-api/).


### PR DESCRIPTION
- bump version to kubernetes package to `2.0.1-1.12.2`
- update the install through UI gif to show multiple kubernetes installations 

