### PR TITLE
chore: only use centos 7.5 as universal installer support for coreos is deprecated and will be removed in v0.2.0 DC/OS terraform modules

### DIFF
--- a/resources/desired_cluster_profile.aws.tfvars
+++ b/resources/desired_cluster_profile.aws.tfvars
@@ -8,7 +8,6 @@ num_of_masters = "1"
 num_of_private_agents = "4"
 num_of_public_agents = "1"
 
-instance_os = "centos_7.5"
 bootstrap_instance_type = "m5.large"
 master_instance_type = "m5.2xlarge"
 private_agent_instance_type = "m5.2xlarge"

--- a/resources/desired_cluster_profile.gcp.tfvars
+++ b/resources/desired_cluster_profile.gcp.tfvars
@@ -8,7 +8,6 @@ num_of_masters = "1"
 num_of_private_agents = "4"
 num_of_public_agents = "1"
 
-instance_os = "coreos_1855.5.0"
 bootstrap_instance_type = "n1-standard-1"
 master_instance_type = "n1-standard-8"
 private_agent_instance_type = "n1-standard-8"

--- a/resources/variables.gcp.tf
+++ b/resources/variables.gcp.tf
@@ -63,7 +63,7 @@ variable "num_of_masters" {
 
 variable "instance_os" {
   description = "Operating system to use."
-  default = "coreos_1855.5.0"
+  default = "centos_7.5"
 }
 
 variable "bootstrap_machine_type" {


### PR DESCRIPTION
I've tested this and it works fine, passes conformance tests.